### PR TITLE
fix/manage-rules-booster

### DIFF
--- a/manage/rules/booster.mdx
+++ b/manage/rules/booster.mdx
@@ -34,7 +34,7 @@ For example, consider the following order details:
 - Total: $110
 
 In this scenario, the order qualifies for the cart booster rule bonus
-since its total of $110 exceeds the threshold of $100.
+since its total of \$110 exceeds the threshold of \$100.
 The customer will get 1,100 points for their loyalty according to the value set for the loyalty rule.
 In addition, the customer will receive 50% of the points they earned through the loyalty rule, thus 550 points.
 In total, the customer will be awarded 1,100 points + 550 points = 1,650 points.


### PR DESCRIPTION
Fix the text in Italics to match the primary font for documentation.

![Screenshot of Cart booster - Beans Help Center (2)](https://github.com/user-attachments/assets/8d34bb0e-b07b-484e-a71e-b5ff9d8147de)
